### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ if (project.hasProperty('platformVersion')) {
 group = 'org.springframework.integration'
 
 repositories {
-	maven { url 'http://repo.spring.io/libs-snapshot' }
+	maven { url 'https://repo.spring.io/libs-snapshot' }
 }
 
 compileJava {
@@ -73,8 +73,8 @@ ext {
 	shortName = 'flow'
 }
 
-// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 configurations {
 	jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 }

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://spring.io migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html migrated to:  
  https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html ([https](https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html) result 301).
* http://www.gradle.org/docs/current/userguide/dependency_management.html migrated to:  
  https://www.gradle.org/docs/current/userguide/dependency_management.html ([https](https://www.gradle.org/docs/current/userguide/dependency_management.html) result 301).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).