### PR TITLE
URL Cleanup

### DIFF
--- a/src/test/java/org/springframework/integration/flow/config/xml/FlowClientNamespaceTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/FlowClientNamespaceTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
     <!-- Instantiate the flow (folded into its own application context) -->
     <int-flow:flow id="subflow1" />

--- a/src/test/java/org/springframework/integration/flow/config/xml/FlowConfigNamespaceTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/FlowConfigNamespaceTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 	<int-flow:flow-configuration>
 
 		<int-flow:port-mapping>

--- a/src/test/java/org/springframework/integration/flow/config/xml/FlowContextTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/FlowContextTests-context.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:int="http://www.springframework.org/schema/integration"
     xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
-    xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
  
 	<!-- Instantiate the flow -->
 	<int-flow:flow id="subflow" flow-id="flow-with-channel-conflict"/>

--- a/src/test/java/org/springframework/integration/flow/config/xml/FlowContextTests-jmx-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/FlowContextTests-jmx-context.xml
@@ -6,12 +6,12 @@
     xmlns:context="http://www.springframework.org/schema/context"
     xmlns:int-jmx="http://www.springframework.org/schema/integration/jmx"
     xmlns:util="http://www.springframework.org/schema/util"
-    xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jmx https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
     
     
     <context:mbean-server/>

--- a/src/test/java/org/springframework/integration/flow/config/xml/FlowWithAutowireTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/FlowWithAutowireTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <int-flow:flow id="autowired" 
     	referenced-bean-locations="/org/springframework/integration/flow/config/xml/autowired-referenced-beans.xml"/>

--- a/src/test/java/org/springframework/integration/flow/config/xml/FlowWithErrorTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/FlowWithErrorTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<int-flow:flow id="subflow4"/>
 	<int-flow:flow id="subflow5"/>

--- a/src/test/java/org/springframework/integration/flow/config/xml/FlowWithOptionalResponseTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/FlowWithOptionalResponseTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
  <!-- Instantiate the flow -->
     <int-flow:flow id="no-response"/>

--- a/src/test/java/org/springframework/integration/flow/config/xml/FlowWithReferencesTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/FlowWithReferencesTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
  
 

--- a/src/test/java/org/springframework/integration/flow/config/xml/NestedFlowTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/NestedFlowTests-context.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:int="http://www.springframework.org/schema/integration"
     xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
-    xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
  
  
 	<int-flow:flow id="nested"/>

--- a/src/test/java/org/springframework/integration/flow/config/xml/TransactionalFlowTests-context.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/TransactionalFlowTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
  	
 	<int-flow:flow id="transactional-flow"/>
 	

--- a/src/test/java/org/springframework/integration/flow/config/xml/autowired-referenced-beans.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/autowired-referenced-beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean class="org.springframework.integration.flow.config.xml.FooFactory"/>
     <bean class="org.springframework.integration.flow.config.xml.Bar"/>

--- a/src/test/java/org/springframework/integration/flow/config/xml/ref-bean-config.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/ref-bean-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 	
 	<bean id="refbean" class="org.springframework.integration.flow.config.xml.RefBean">
 		<property name="value" value="it works!"/>

--- a/src/test/java/org/springframework/integration/flow/config/xml/txmanager-config.xml
+++ b/src/test/java/org/springframework/integration/flow/config/xml/txmanager-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="transactionManager" class="org.springframework.integration.flow.Transaction.StubTransactionManager"/>    
 </beans>

--- a/src/test/resources/META-INF/spring/integration/flows/autowired/autowired-flow-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/autowired/autowired-flow-context.xml
@@ -4,10 +4,10 @@
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:annotation-config/>
     

--- a/src/test/resources/META-INF/spring/integration/flows/basic1/flow-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/basic1/flow-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
     <int-flow:flow-configuration>
      <int-flow:port-mapping input-channel="basic1.inputChannel" output-channel="basic1.outputChannel"/>

--- a/src/test/resources/META-INF/spring/integration/flows/basic2/flow-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/basic2/flow-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
     <int-flow:flow-configuration>
      <int-flow:port-mapping input-channel="basic2.inputChannel" output-channel="basic2.outputChannel"/>

--- a/src/test/resources/META-INF/spring/integration/flows/flow-with-channel-conflict/invalid-flow-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/flow-with-channel-conflict/invalid-flow-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 	
 	<int-flow:flow-configuration>
 		<int-flow:port-mapping input-channel="inputC" output-channel="outputC"/>	 

--- a/src/test/resources/META-INF/spring/integration/flows/nested/flow-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/nested/flow-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <int-flow:flow-configuration>
      <int-flow:port-mapping input-channel="nested.inputChannel" output-channel="nested.outputChannel"/>

--- a/src/test/resources/META-INF/spring/integration/flows/no-response/flow-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/no-response/flow-context.xml
@@ -4,10 +4,10 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<int-flow:flow-configuration> 
 		<int-flow:port-mapping input-channel="flow-input"/>  

--- a/src/test/resources/META-INF/spring/integration/flows/optional-response/flow-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/optional-response/flow-context.xml
@@ -4,10 +4,10 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<int-flow:flow-configuration> 
 		<int-flow:port-mapping input-channel="flow-input" output-channel="flow-output"/> 

--- a/src/test/resources/META-INF/spring/integration/flows/subflow1-bean-config.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/subflow1-bean-config.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
       
      

--- a/src/test/resources/META-INF/spring/integration/flows/subflow1/subflow1-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/subflow1/subflow1-context.xml
@@ -4,10 +4,10 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<int-flow:flow-configuration> 
 		<int-flow:port-mapping>

--- a/src/test/resources/META-INF/spring/integration/flows/subflow2/subflow2-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/subflow2/subflow2-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<!-- Need to set ignore-unresolvable true or provide defaults for required properties -->
 	<context:property-placeholder/> 

--- a/src/test/resources/META-INF/spring/integration/flows/subflow4/subflow4-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/subflow4/subflow4-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 	
 	<int-flow:flow-configuration>
         <int-flow:port-mapping input-channel="subflow-input" output-channel="subflow-output"/> 

--- a/src/test/resources/META-INF/spring/integration/flows/subflow5/subflow5-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/subflow5/subflow5-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 	
 	<int-flow:flow-configuration>
 		<int-flow:port-mapping>

--- a/src/test/resources/META-INF/spring/integration/flows/transactional-flow/flow-context.xml
+++ b/src/test/resources/META-INF/spring/integration/flows/transactional-flow/flow-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-flow="http://www.springframework.org/schema/integration/flow"
 	xmlns:int-script="http://www.springframework.org/schema/integration/scripting"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/flow http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/scripting http://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/flow https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/scripting https://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 	
 	<int-flow:flow-configuration>
 		<int-flow:port-mapping input-channel="inputChannel" output-channel="outputChannel"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd (404) with 22 occurrences migrated to:  
  https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd ([https](https://www.springframework.org/schema/integration/flow/spring-integration-flow.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 25 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd ([https](https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd) result 200).
* http://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd ([https](https://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration.xsd with 22 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx.xsd ([https](https://www.springframework.org/schema/tx/spring-tx.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 11 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 52 occurrences
* http://www.springframework.org/schema/context with 12 occurrences
* http://www.springframework.org/schema/integration with 44 occurrences
* http://www.springframework.org/schema/integration/flow with 44 occurrences
* http://www.springframework.org/schema/integration/jmx with 2 occurrences
* http://www.springframework.org/schema/integration/scripting with 2 occurrences
* http://www.springframework.org/schema/tx with 2 occurrences
* http://www.springframework.org/schema/util with 22 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 26 occurrences